### PR TITLE
 fix usage of LineNumberNode constructor on 1.5

### DIFF
--- a/src/AbstractPatterns/AbstractPatterns.jl
+++ b/src/AbstractPatterns/AbstractPatterns.jl
@@ -31,7 +31,7 @@ function init_cfg(cfg::CFGSpec)
     exp
 end
 
-const _const_lineno = LineNumberNode(32, "<codegen>")
+const _const_lineno = LineNumberNode(32, Symbol("<codegen>"))
 function init_cfg!(ex::Expr, cf_info::Dict{Symbol, Symbol})
     args = ex.args
     for i in eachindex(args)


### PR DESCRIPTION
This now requires the second argument to be a symbol.